### PR TITLE
Add support for environment variables for creds & cross-OS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,10 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# virtual python environment
+bin
+pyvenv.cfg
+
 # Pyre type checker
 .pyre/
 

--- a/RARPC.py
+++ b/RARPC.py
@@ -105,6 +105,10 @@ def updatePresence(RPC, userProfile, recentlyPlayedGame, isDisplayUsername, star
         )
     except:
         print(Fore.RED + "Failed to update presence.")
+        while(isDiscordRPCAvailable(RPC) == False):
+            print(Fore.RED + "Retrying in 10 seconds...")
+            time.sleep(10)
+        RPC.connect()
         pass
         
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ _Note: Running it silently/in the background isn't allowed with the `exe` file. 
 5. Go to Discord > User Settings > Activity Privacy. Toggle on `Share your detected activity with others.`
 6. Run the `run.bat` file, enter your credentials, `username` and `api key` from RetroAchievements.
 
+Note: You may alternatively store your credentials via environment variables `RETROACHIEVEMENTS_USERNAME` and `RETROACHIEVEMENTS_API_KEY`. If set, they will be used by default.
+
 After running the `run.bat` file, a `config.ini` file will be created in the same directory. The credentials that you've submitted are stored in this config file.
 
 ### If you want to run the batch file in the background:


### PR DESCRIPTION
**Cross-OS Support for the Discord Application**
Instead of checking for Discord.exe (which is typically the name of the application running on Windows) it will check for the existence of Discord RPC. This allows the script to work with Mac and Linux, which have different names for the Discord app.

**Environment variable support for credentials**
Some users may prefer to store their credentials as environment variables. This adds support for that, skipping this step of the config setup if environment variables are set. The values do not get written to config if set as an environment variable. A note has been added to the README.

**Discord Client Error-handling**
I noticed that if the Discord client quits or is RPC is otherwise not available, the script crashes and quits. I added error-handling logic to gracefully enter the reconnect loop for RPC if it becomes unavailable, allowing it to continue to run in the background.

Side note -- thanks for your work on this project, hoping you don't mind some small contributions!